### PR TITLE
Disable spdlog by default in sandbox

### DIFF
--- a/SandBox/src/SandBoxApp.cpp
+++ b/SandBox/src/SandBoxApp.cpp
@@ -1,7 +1,8 @@
+#include <Utopia.hpp>
+
 // Needs to build with spdlog to use log system
 #define UT_USE_SPDLOG
-
-#include <Utopia.hpp>
+#include <Utopia/Log.hpp>
 
 class LayerTest : public Utopia::Layer
 {

--- a/SandBox/src/SandBoxApp.cpp
+++ b/SandBox/src/SandBoxApp.cpp
@@ -1,5 +1,7 @@
-#include <Utopia.hpp>
+// Needs to build with spdlog to use log system
+#define UT_USE_SPDLOG
 
+#include <Utopia.hpp>
 
 class LayerTest : public Utopia::Layer
 {

--- a/Utopia/src/Utopia.hpp
+++ b/Utopia/src/Utopia.hpp
@@ -3,7 +3,6 @@
 // Unique for Utopia App
 
 #include "Utopia/Application.hpp"
-#include "Utopia/Log.hpp"
 #include "Utopia/Layer/Layer.hpp"
 #include "Utopia/ImGui/ImGuiLayer.hpp"
 #include "Utopia/Input.hpp"

--- a/Utopia/src/Utopia/Application.hpp
+++ b/Utopia/src/Utopia/Application.hpp
@@ -4,7 +4,6 @@
 #include "Utopia/Window.hpp"
 #include "Utopia/Layer/LayerStack.hpp"
 
-
 namespace Utopia
 {
 	class UTOPIA_API Application

--- a/Utopia/src/Utopia/Log.hpp
+++ b/Utopia/src/Utopia/Log.hpp
@@ -2,7 +2,10 @@
 
 #include "Core.hpp"
 
-// TODO: Remove deps to spdlog
+#ifndef UT_USE_SPDLOG
+#error You can't use the logging system without spdlog
+#endif
+
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
 

--- a/Utopia/src/Utopia/Log.hpp
+++ b/Utopia/src/Utopia/Log.hpp
@@ -2,10 +2,6 @@
 
 #include "Core.hpp"
 
-#ifndef UT_USE_SPDLOG
-#error You can't use the logging system without spdlog
-#endif
-
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -36,6 +36,7 @@ target("Utopia")
     add_packages("glad")
     add_packages("imgui")
 
+    add_defines("UT_USE_SPDLOG")
     if is_plat("windows") then
         add_defines("UT_PLATFORM_WINDOWS", "UT_BUILD_DLL")
     end


### PR DESCRIPTION
Figured out it will not work out of the box because of **templates in hpp using the Log class**